### PR TITLE
Update external APB urls to point to registering

### DIFF
--- a/external/apb/android-app.html
+++ b/external/apb/android-app.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; URL='./../../aerogear/latest/mobile-clients.html#running'" />
+<meta http-equiv="refresh" content="0; URL='./../../aerogear/latest/mobile-clients.html#android'" />

--- a/external/apb/cordova-app.html
+++ b/external/apb/cordova-app.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; URL='./../../aerogear/latest/mobile-clients.html#running'" />
+<meta http-equiv="refresh" content="0; URL='./../../aerogear/latest/mobile-clients.html#cordova'" />

--- a/external/apb/ios-app.html
+++ b/external/apb/ios-app.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; URL='./../../aerogear/latest/mobile-clients.html#running'" />
+<meta http-equiv="refresh" content="0; URL='./../../aerogear/latest/mobile-clients.html#ios'" />

--- a/external/apb/xamarin-app.html
+++ b/external/apb/xamarin-app.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; URL='./../../aerogear/latest/mobile-clients.html#running'" />
+<meta http-equiv="refresh" content="0; URL='./../../aerogear/latest/mobile-clients.html#xamarin'" />


### PR DESCRIPTION
Currently we are pointing to running, this does not exist, which
just brings the user to the top of the Mobile Clients page.