### PR TITLE
add redirect for walkthrough

### DIFF
--- a/limited-availability/downstream/walkthrough.html
+++ b/limited-availability/downstream/walkthrough.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; URL='https://finp.github.io/mobile-docs-midstream/index.html'" />


### PR DESCRIPTION
## Motivation
we've got a temp website for downstream docs, but need to add a link to walkthrough
This redirect allows us to put a url into walkthrough that can be updated when the downstream docs are published to customer portal